### PR TITLE
Fix: Added intersections and selections by query string (fixes #2)

### DIFF
--- a/js/AdaptModelSet.js
+++ b/js/AdaptModelSet.js
@@ -22,6 +22,10 @@ export default class AdaptModelSet {
     return this._model.get('_component');
   }
 
+  modelTypeGroup(group) {
+    return this._model.isTypeGroup(group);
+  }
+
   get models() {
     return this._models;
   }

--- a/js/AdaptModelSet.js
+++ b/js/AdaptModelSet.js
@@ -14,6 +14,14 @@ export default class AdaptModelSet {
     this._subsetParent = subsetParent;
   }
 
+  get modelType() {
+    return this._model.get('_type');
+  }
+
+  get modelComponent() {
+    return this._model.get('_component');
+  }
+
   get models() {
     return this._models;
   }

--- a/js/AdaptModelSet.js
+++ b/js/AdaptModelSet.js
@@ -1,0 +1,30 @@
+import data from 'core/js/data';
+
+export default class AdaptModelSet {
+  constructor({
+    _id,
+    model = null
+  }, subsetParent) {
+    model = model ?? data.findById(_id);
+    const id = _id ?? model.get('_id');
+    this._id = id;
+    this._type = 'adapt';
+    this._model = model;
+    this._models = [model];
+    this._subsetParent = subsetParent;
+  }
+
+  get models() {
+    return this._models;
+  }
+
+  get isComplete() {
+    return this._model.get('_isComplete');
+  }
+
+  get isPassed() {
+    return null;
+  }
+}
+
+// Is extended by ScoringSet later

--- a/js/ScoringSet.js
+++ b/js/ScoringSet.js
@@ -161,6 +161,16 @@ export default class ScoringSet extends Backbone.Controller {
     return this._subsetParent;
   }
 
+  get subsetPath() {
+    let subject = this;
+    const path = [];
+    while (subject) {
+      path.push(subject);
+      subject = subject.subsetParent;
+    }
+    return path.reverse();
+  }
+
   get id() {
     return this._id;
   }
@@ -294,19 +304,20 @@ export default class ScoringSet extends Backbone.Controller {
    */
   get stateObject() {
     return {
-      id: this.id,
-      type: this.type,
-      title: this.title,
-      isScoreIncluded: this.isScoreIncluded,
-      isCompletionRequired: this.isCompletionRequired,
-      minScore: this.minScore,
-      maxScore: this.maxScore,
-      score: this.score,
-      scaledScore: this.scaledScore,
       correctness: this.correctness,
-      scaledCorrectness: this.scaledCorrectness,
+      id: this.id,
       isComplete: this.isComplete,
-      isPassed: this.isPassed
+      isCompletionRequired: this.isCompletionRequired,
+      isPassed: this.isPassed,
+      isScoreIncluded: this.isScoreIncluded,
+      maxScore: this.maxScore,
+      minScore: this.minScore,
+      scaledCorrectness: this.scaledCorrectness,
+      scaledScore: this.scaledScore,
+      score: this.score,
+      subsetPath: this.subsetPath.map(subset => subset.id).join('.'),
+      title: this.title,
+      type: this.type
     };
   }
 

--- a/js/ScoringSet.js
+++ b/js/ScoringSet.js
@@ -204,6 +204,10 @@ class ScoringSet extends Backbone.Controller {
     return Boolean(this.models?.length);
   }
 
+  get isNotPopulated() {
+    return Boolean(this.models?.length);
+  }
+
   /**
    * Returns all `_isAvailable` component models
    * @returns {[ComponentModel]}
@@ -305,12 +309,20 @@ class ScoringSet extends Backbone.Controller {
     Logging.error(`isComplete must be overriden for ${this.constructor.name}`);
   }
 
+  get isIncomplete() {
+    return (this.isComplete === false);
+  }
+
   /**
    * Returns whether the configured passmark has been achieved
    * @returns {boolean}
    */
   get isPassed() {
     Logging.error(`isPassed must be overriden for ${this.constructor.name}`);
+  }
+
+  get isFailed() {
+    return (this.isPassed === false);
   }
 
   /**

--- a/js/ScoringSet.js
+++ b/js/ScoringSet.js
@@ -9,6 +9,8 @@ import scoring, {
   getSubsetsByModelId,
   getSubsetById,
   getSubSetByPath,
+  getSubsetsByQuery,
+  getStateObjectsByQuery,
   isAvailableInHierarchy
 } from './adapt-contrib-scoring';
 import Backbone from 'backbone';
@@ -125,6 +127,22 @@ export default class ScoringSet extends Backbone.Controller {
    */
   getSubsetByPath(path) {
     return getSubSetByPath(path, this);
+  }
+
+  /**
+   * @param {string} query
+   * @returns {[ScoringSet]}
+   */
+  getSubsetsByQuery(query) {
+    return getSubsetsByQuery(query, this);
+  }
+
+  /**
+   * @param {string} query
+   * @returns {[object]}
+   */
+  getStateObjectsByQuery(query) {
+    return getStateObjectsByQuery(query, this);
   }
 
   /**
@@ -251,6 +269,45 @@ export default class ScoringSet extends Backbone.Controller {
   get scoreAsstring() {
     const score = this.score;
     return (score > 0) ? `+${score.toString()}` : score.toString();
+  }
+
+  /**
+   * Returns the number of correctly answered questions
+   * @returns {number}
+   */
+  get correctness() {
+    Logging.error(`correctness must be overriden for ${this.constructor.name}`);
+  }
+
+  /**
+     * Returns the percentage of correctly answered questions
+     * @returns {number}
+     */
+  get scaledCorrectness() {
+    Logging.error(`scaledCorrectness must be overriden for ${this.constructor.name}`);
+  }
+
+  /**
+   * Returns an object representing the set state
+   * This is useful for rendering UI
+   * @returns {object}
+   */
+  get stateObject() {
+    return {
+      id: this.id,
+      type: this.type,
+      title: this.title,
+      isScoreIncluded: this.isScoreIncluded,
+      isCompletionRequired: this.isCompletionRequired,
+      minScore: this.minScore,
+      maxScore: this.maxScore,
+      score: this.score,
+      scaledScore: this.scaledScore,
+      correctness: this.correctness,
+      scaledCorrectness: this.scaledCorrectness,
+      isComplete: this.isComplete,
+      isPassed: this.isPassed
+    };
   }
 
   /**

--- a/js/ScoringSet.js
+++ b/js/ScoringSet.js
@@ -205,7 +205,7 @@ class ScoringSet extends Backbone.Controller {
   }
 
   get isNotPopulated() {
-    return Boolean(this.models?.length);
+    return (this.isPopulated === false);
   }
 
   /**

--- a/js/ScoringSet.js
+++ b/js/ScoringSet.js
@@ -143,7 +143,7 @@ class ScoringSet extends Backbone.Controller {
    * @returns {[ScoringSet]}
    */
   getPopulatedSubset(subset) {
-    return subset.filter(set => set.models.length > 0);
+    return subset.filter(set => set.isPopulated);
   }
 
   /**
@@ -194,6 +194,14 @@ class ScoringSet extends Backbone.Controller {
    */
   get models() {
     Logging.error(`models must be overriden for ${this.constructor.name}`);
+  }
+
+  /**
+   * Check to see if there are any child models
+   * @returns {boolean}
+   */
+  get isPopulated() {
+    return Boolean(this.models?.length);
   }
 
   /**

--- a/js/adapt-contrib-scoring.js
+++ b/js/adapt-contrib-scoring.js
@@ -13,10 +13,10 @@ import {
   getSubsetsByModelId,
   getSubSetByPath,
   getSubsetsByQuery,
-  getStateObjectsByQuery,
   getScaledScoreFromMinMax,
   isAvailableInHierarchy
 } from './utils';
+import AdaptModelSet from './AdaptModelSet';
 
 export {
   filterModels,
@@ -30,9 +30,9 @@ export {
   getSubsetsByModelId,
   getSubSetByPath,
   getSubsetsByQuery,
-  getStateObjectsByQuery,
   getScaledScoreFromMinMax,
-  isAvailableInHierarchy
+  isAvailableInHierarchy,
+  AdaptModelSet
 };
 
 /**
@@ -52,8 +52,13 @@ class Scoring extends Backbone.Controller {
   onAdaptStart() {
     // delay any listeners until all data has been restored
     this._setupListeners();
+    this.makeAdaptModelSets();
     this.init();
     this.update();
+  }
+
+  makeAdaptModelSets() {
+    data.forEach(model => this.register(new AdaptModelSet({ model })));
   }
 
   _setupListeners() {
@@ -175,14 +180,6 @@ class Scoring extends Backbone.Controller {
    */
   getSubsetsByQuery(query) {
     return getSubsetsByQuery(query);
-  }
-
-  /**
-   * @param {string} query
-   * @returns {[object]}
-   */
-  getStateObjectsByQuery(query) {
-    return getStateObjectsByQuery(query);
   }
 
   /**

--- a/js/adapt-contrib-scoring.js
+++ b/js/adapt-contrib-scoring.js
@@ -12,6 +12,8 @@ import {
   getSubsetsByType,
   getSubsetsByModelId,
   getSubSetByPath,
+  getSubsetsByQuery,
+  getStateObjectsByQuery,
   getScaledScoreFromMinMax,
   isAvailableInHierarchy
 } from './utils';
@@ -27,6 +29,8 @@ export {
   getSubsetsByType,
   getSubsetsByModelId,
   getSubSetByPath,
+  getSubsetsByQuery,
+  getStateObjectsByQuery,
   getScaledScoreFromMinMax,
   isAvailableInHierarchy
 };
@@ -157,11 +161,28 @@ class Scoring extends Backbone.Controller {
 
   /**
    * Returns a root set or intersection set by path
-   * @param {string|[string]} path
+   * @param {string} path
    * @returns {ScoringSet}
    */
   getSubsetByPath(path) {
     return getSubSetByPath(path);
+  }
+
+  /**
+   * Returns sets or intersection sets by query
+   * @param {string} query
+   * @returns {ScoringSet}
+   */
+  getSubsetsByQuery(query) {
+    return getSubsetsByQuery(query);
+  }
+
+  /**
+   * @param {string} query
+   * @returns {[object]}
+   */
+  getStateObjectsByQuery(query) {
+    return getStateObjectsByQuery(query);
   }
 
   /**

--- a/js/adapt-contrib-scoring.js
+++ b/js/adapt-contrib-scoring.js
@@ -1,6 +1,7 @@
 import Backbone from 'backbone';
 import Adapt from 'core/js/adapt';
 import data from 'core/js/data';
+import './helpers';
 import {
   filterModels,
   filterIntersectingHierarchy,

--- a/js/adapt-contrib-scoring.js
+++ b/js/adapt-contrib-scoring.js
@@ -47,18 +47,27 @@ class Scoring extends Backbone.Controller {
      */
     this._rawSets = [];
     this.listenTo(Adapt, 'adapt:start', this.onAdaptStart);
+    this.listenTo(data, {
+      add: this.addModel,
+      remove: this.removeModel
+    });
   }
 
   onAdaptStart() {
     // delay any listeners until all data has been restored
     this._setupListeners();
-    this.makeAdaptModelSets();
     this.init();
     this.update();
   }
 
-  makeAdaptModelSets() {
-    data.forEach(model => this.register(new AdaptModelSet({ model })));
+  addModel(model) {
+    this.register(new AdaptModelSet({ model }));
+  }
+
+  removeModel(model) {
+    const id = model.get('_id');
+    const setIndex = this._rawSets.findIndex(set => set.id === id);
+    this._rawSets.splice(setIndex, 1);
   }
 
   _setupListeners() {

--- a/js/adapt-contrib-scoring.js
+++ b/js/adapt-contrib-scoring.js
@@ -161,7 +161,7 @@ class Scoring extends Backbone.Controller {
 
   /**
    * Returns a root set or intersection set by path
-   * @param {string} path
+   * @param {string|[string]} path
    * @returns {ScoringSet}
    */
   getSubsetByPath(path) {

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -1,30 +1,24 @@
-import data from 'core/js/data';
 import Handlebars from 'handlebars';
-// import {
-//   getSubsetById
-// } from './utils';
+import {
+  getSubsetsByQuery
+} from './utils';
 
 const helpers = {
-  'set-score'(setId, context) {
-    if (!context) throw Error('No context for set-score helper.');
-    // const data = context.data.root;
-    // const modelId = data._id;
-    // const score = null;
-    // const set = getSubsetById(setId);
-    // const score = set.models.find
-    // const sets = getSubsetsByModelId(modelId);
-    // sets.find(set => set.id === setId)
-    // return score;
-  },
-
-  score(context) {
-    if (!context) throw Error('No context for score helper.');
-    const root = context.data.root;
-    const modelId = root._id;
-    const model = data.findById(modelId);
-    const score = model.score;
-    return score;
+  scoreQuery(query, context) {
+    const modelId = context?.data?.root?._id;
+    query = query.replace('this', `#${modelId}`);
+    const sets = getSubsetsByQuery(query);
+    return sets.reduce((score, set) => score + set.score, 0);
   }
+
+  // score(context) {
+  //   if (!context) throw Error('No context for score helper.');
+  //   const root = context.data.root;
+  //   const modelId = root._id;
+  //   const model = data.findById(modelId);
+  //   const score = model.score;
+  //   return score;
+  // }
 };
 
 for (const name in helpers) {

--- a/js/utils.js
+++ b/js/utils.js
@@ -198,8 +198,8 @@ export function isAvailableInHierarchy(model) {
  * @returns {[any]}
  */
 export function matrixMultiply (matrix) {
-  const partLengths = matrix.map(part => part.length); // how large each part is
-  const subPartIndices = '0'.repeat(matrix.length).split('').map(Number); // how far we've gone in each part
+  const partLengths = matrix.map(part => part.length); // how large each row is
+  const subPartIndices = '0'.repeat(matrix.length).split('').map(Number); // how far we've gone in each row
   let isEnded = false;
   const sumsToPerform = [];
   while (isEnded === false) {

--- a/js/utils.js
+++ b/js/utils.js
@@ -285,7 +285,18 @@ export function getSubsetsByQuery(query, subsetParent = undefined) {
           : getSubsetsByModelId(filter.modelId, subsetParent);
         if (hasModelIdFilter) delete filter.modelId;
         // Return only filtered sets
-        const attributeFilteredSubsets = _.where(filterSubsets, filter);
+        const attributeFilteredSubsets = filterSubsets.filter(set => {
+          for (const k in filter) {
+            const setValue = set[k];
+            const value = filter[k];
+            if (typeof setValue === 'function') {
+              if (!setValue.call(set, value)) return false;
+              continue;
+            }
+            if (setValue !== value) return false;
+          }
+          return true;
+        });
         return attributeFilteredSubsets;
       })
       .flat();

--- a/js/utils.js
+++ b/js/utils.js
@@ -220,7 +220,7 @@ export function matrixMultiply (matrix) {
   return sumsToPerform;
 }
 
-const majorPartRegExp = /([^ []+(?:\[[^\]]+\])*)/g;
+const majorPartRegExp = /([^ []*(?:\[[^\]]+\])*)/g;
 const attributePartRegEx = /\[([^\]]+)\]/g;
 /**
  * Takes a subset intersection query string and transforms it into an array of filter objects

--- a/js/utils.js
+++ b/js/utils.js
@@ -220,17 +220,18 @@ export function matrixMultiply (matrix) {
   return sumsToPerform;
 }
 
-const attributePathRegEx = /\[([^\]]+)\]/g;
+const majorPartRegExp = /([^ []+(?:\[[^\]]+\])*)/g;
+const attributePartRegEx = /\[([^\]]+)\]/g;
 /**
  * Takes a subset intersection query string and transforms it into an array of filter objects
  * @param {string} query
  * @returns {[[{}]]}
  */
 export function parseQuery(query = '') {
-  const queryMajors = query.split(/([^ []+\[[^\]]+\]*)/).map(section => section.trim()).filter(Boolean);
+  const queryMajors = query.split(majorPartRegExp).map(section => section?.trim()).filter(Boolean);
   const filterParts = queryMajors.map(queryMajor => {
-    const attributeQueryParts = queryMajor.match(attributePathRegEx);
-    const openingQueryPart = queryMajor.replace(attributePathRegEx, '');
+    const attributeQueryParts = queryMajor.match(attributePartRegEx);
+    const openingQueryPart = queryMajor.replace(attributePartRegEx, '');
     const majorFilterPart = [];
     if (openingQueryPart[0] === '#') {
       // select by id

--- a/js/utils.js
+++ b/js/utils.js
@@ -249,6 +249,9 @@ export function parseQuery(query = '') {
         const attributeQueryPartMiddle = attributeQueryPart.slice(1, -1);
         const attributeQueryPartSections = attributeQueryPartMiddle.split(',').map(section => section.trim()).filter(Boolean);
         const attributeFilterPart = attributeQueryPartSections.map(section => {
+          if (section[0] === '#') {
+            return { id: section.slice(1) };
+          }
           const [name, value] = section.split('=').map(section => section.trim()).filter(Boolean);
           return { [name]: value };
         });

--- a/js/utils.js
+++ b/js/utils.js
@@ -237,7 +237,7 @@ export function parseQuery(query = '') {
       majorFilterPart.push({
         id: openingQueryPart.slice(1)
       });
-    } else {
+    } else if (openingQueryPart) {
       // select by type
       majorFilterPart.push({
         type: openingQueryPart

--- a/js/utils.js
+++ b/js/utils.js
@@ -281,12 +281,12 @@ export function getSubsetsByQuery(query, subsetParent = undefined) {
     // Return only filtered sets
     return _.where(filterSubsets, filter);
   }).flat());
-  const subsetQueryList = matrixMultiply(subsetQueryMatrix);
-  const subsets = subsetQueryList.map(subsetQueryItem => {
-    if (subsetParent) return createIntersectionSubset([subsetParent, ...subsetQueryItem]);
-    return createIntersectionSubset(subsetQueryItem);
+  const intersectionQueryLists = matrixMultiply(subsetQueryMatrix);
+  const intersectedSubsets = intersectionQueryLists.map(intersectionQueryList => {
+    if (subsetParent) return createIntersectionSubset([subsetParent, ...intersectionQueryList]);
+    return createIntersectionSubset(intersectionQueryList);
   });
-  return subsets;
+  return intersectedSubsets;
 }
 
 /**

--- a/js/utils.js
+++ b/js/utils.js
@@ -299,13 +299,3 @@ export function getSubsetsByQuery(query, subsetParent = undefined) {
   });
   return intersectedSubsets;
 }
-
-/**
- * Takes a subset intersection query string and returns the resultant subsets state objects
- * @param {string} query
- * @param {ScoringSet} [subsetParent]
- * @returns {[object]}
- */
-export function getStateObjectsByQuery(query, subsetParent = undefined) {
-  return getSubsetsByQuery(query, subsetParent).map(set => set.stateObject);
-}

--- a/js/utils.js
+++ b/js/utils.js
@@ -299,7 +299,7 @@ export function getSubsetsByQuery(query, subsetParent = undefined) {
       }
       if (filterValue === undefined) {
         if (!setValue) return false; // check for Boolean(isComplete)
-      } else if (setValue !== filterValue) {
+      } else if (String(setValue) !== String(filterValue)) {
         return false; // check for id==='a-05'
       }
     }

--- a/js/utils.js
+++ b/js/utils.js
@@ -327,6 +327,7 @@ export function getSubsetsByQuery(query, subsetParent = undefined) {
     if (subsetParent) return createIntersectionSubset([subsetParent, ...intersectionQueryList]);
     return createIntersectionSubset(intersectionQueryList);
   });
+  // TODO: might have to allow post filters on each row columns, such that [modelType=article](isComplete) test(isPassed) works
   let postFilteredSubsets = intersectedSubsets;
   parsedQueryMatrix.forEach(row => {
     const inclusionFilters = row.lastItem;


### PR DESCRIPTION
fixes #2 

Query examples:
```js
"test" // Select sets of type 'test'
"#test-01" // Select set with id 'test-01'
"#a-500" // Select set for Adapt id "a-500"
"test[id=test-01]" // Select set with id 'test-01'
"test[modelId=a-05]" // Select sets intersecting model 'a-05'
"test[id=test-01] test[id=test-05]" // Create an intersection of set 'test-01' and 'test-05'
"test[id=test-01,id=test-05] test[id=test-10,test-15]" // Create an intersection of sets 'test-01' and 'test-10'. 'test-01' and 'test-15', 'test-05' and 'test-10' and 'test-05' and 'test-15'
"[id=test-01,id=test-05] [id=test-10,id=test-15]" // Would do the same
"[#test-01,#test-05] [#test-10,#test-15]" // Would do the same
"adapt[modelType=article]" // Return the scorings sets for all articles
"adapt[modelComponent=mcq]" // Return the scorings sets for all mcqs
"adapt[modelComponent=mcq,modelComponent=gmcq]" // Return the scorings sets for all mcqs and gmcqs
"adapt[modelTypeGroup=question]" // Return all question scoring sets
"adapt[modelComponent=mcq,modelComponent=gmcq](isComplete)" // Return all complete mcq and gmcq scoring sets
"adapt[modelComponent=mcq,modelComponent=gmcq](isComplete,isPassed)" // Return all complete and passed mcq and gmcq scoring sets
"[modelType=article] test" // Returns all article tests
"[modelType=article] test(isPopulated)" // Returns all article tests that have models, i.e. the valid intersections
"[modelType=article](isComplete) test(isPopulated)"// Returns all article tests that have models from completed articles
```

Selection by attribute `[]`/`()`:
```js
"#id" || ["id=id"] // check for an id
"test" || ["type=test"] // check for a set type
"[isComplete]" // check if the set is complete
"[isIncomplete]" // check if the set is incomplete
"[isPassed]"  // check if the set is passed
"[isFailed]"  // check if the set is not passed
"[isPopulated]" // check if the query set has models after intersection filters are applied
"[isNotPopulated]" // check if the query set has no models after intersection filters are applied
[modelId=id] // check if the model intersects the given id
[modelType=type] // check if the model of type course/menu/page/article/block/component
[modelComponent=component] // check if the model of type mcq/gmcq/slider/hotgraphic
[modelTypeGroup=typegroup] // check if the model is of typegroup question/component/contentobject/menu/page
```
Query format:
```js
typeOrId[multipliedbyAttributes](filteredByAttributes)
```
The final set type requested will determine the class type returned.

### New
* `getSubsetsByQuery(query)`  returns the intersecting sets described by the query

