### PR TITLE
Fix: find all intersected sets regardless of availablility

### DIFF
--- a/js/AdaptModelSet.js
+++ b/js/AdaptModelSet.js
@@ -1,4 +1,7 @@
 import ScoringSet from './ScoringSet';
+import {
+  isAvailableInHierarchy
+} from './utils';
 
 export default class AdaptModelSet extends ScoringSet {
 
@@ -63,7 +66,7 @@ export default class AdaptModelSet extends ScoringSet {
    * @override
    */
   get isAvailable() {
-    return this.model.get('_isAvailable');
+    return isAvailableInHierarchy(this.model);
   }
 
   /**

--- a/js/AdaptModelSet.js
+++ b/js/AdaptModelSet.js
@@ -55,15 +55,22 @@ export default class AdaptModelSet extends ScoringSet {
   /**
    * @override
    */
-  get models() {
+  get rawModels() {
     return [this.model];
   }
 
   /**
    * @override
    */
+  get isAvailable() {
+    return this.model.get('_isAvailable');
+  }
+
+  /**
+   * @override
+   */
   get isComplete() {
-    return this._model.get('_isComplete');
+    return this.model.get('_isComplete');
   }
 
   /**
@@ -85,4 +92,3 @@ export default class AdaptModelSet extends ScoringSet {
    */
   onPassed() {}
 }
-

--- a/js/ScoringSet.js
+++ b/js/ScoringSet.js
@@ -207,24 +207,11 @@ export default class ScoringSet extends Backbone.Controller {
   }
 
   /**
-   * Returns a unique array of models, filtered for `_isAvailable` and intersecting subsets hierarchies
-   * Always finish by calling `this.filterModels(models)`
+   * Returns all models regardless of `_isAvailable`
    * @returns {[Backbone.Model]}
    */
-  get models() {
-    Logging.error(`models must be overriden for ${this.constructor.name}`);
-  }
-
-  /**
-   * Check to see if there are any child models
-   * @returns {boolean}
-   */
-  get isPopulated() {
-    return Boolean(this.models?.length);
-  }
-
-  get isNotPopulated() {
-    return (this.isPopulated === false);
+  get rawModels() {
+    Logging.error(`rawModels must be overriden for ${this.constructor.name}`);
   }
 
   /**
@@ -232,7 +219,12 @@ export default class ScoringSet extends Backbone.Controller {
    * @returns {[ComponentModel]}
    */
   get rawComponents() {
-    return this.model.findDescendantModels('component');
+    return this.rawModels.reduce((components, model) => {
+      const models = model.isTypeGroup('component')
+        ? [model]
+        : model.findDescendantModels('component');
+      return components.concat(models);
+    }, []);
   }
 
   /**
@@ -240,7 +232,7 @@ export default class ScoringSet extends Backbone.Controller {
    * @returns {[QuestionModel]}
    */
   get rawQuestions() {
-    return this.model.findDescendantModels('question');
+    return this.rawComponents.filter(model => model.isTypeGroup('question'));
   }
 
   /**
@@ -252,14 +244,20 @@ export default class ScoringSet extends Backbone.Controller {
   }
 
   /**
+   * Returns a unique array of models, filtered for `_isAvailable` and intersecting subsets hierarchies
+   * Always finish by calling `this.filterModels(models)`
+   * @returns {[Backbone.Model]}
+   */
+  get models() {
+    return this.filterModels(this.rawModels);
+  }
+
+  /**
    * Returns all `_isAvailable` component models
    * @returns {[ComponentModel]}
    */
   get components() {
-    return this.models.reduce((components, model) => {
-      model.isTypeGroup('component') ? components.push(model) : components.push(...model.findDescendantModels('component'));
-      return components;
-    }, []).filter(isAvailableInHierarchy);
+    return this.rawComponents.filter(isAvailableInHierarchy);
   }
 
   /**
@@ -275,15 +273,15 @@ export default class ScoringSet extends Backbone.Controller {
    * @returns {[QuestionModel]}
    */
   get questions() {
-    return this.components.filter(model => model.isTypeGroup('question'));
+    return this.rawQuestions.filter(isAvailableInHierarchy);
   }
 
   /**
    * Returns all `_isAvailable` presentation component models
-   * @returns {[QuestionModel]}
+   * @returns {[ComponentModel]}
    */
   get presentationComponents() {
-    return this.components.filter(model => !model.isTypeGroup('question'));
+    return this.rawPresentationComponents.filter(isAvailableInHierarchy);
   }
 
   /**
@@ -357,7 +355,7 @@ export default class ScoringSet extends Backbone.Controller {
    * @returns {boolean}
    */
   get canReset() {
-    return false
+    return false;
   }
 
   /**
@@ -365,7 +363,7 @@ export default class ScoringSet extends Backbone.Controller {
    * @returns {boolean}
    */
   get isOptional() {
-    return false
+    return false;
   }
 
   /**
@@ -373,7 +371,7 @@ export default class ScoringSet extends Backbone.Controller {
    * @returns {boolean}
    */
   get isAvailable() {
-    return true
+    return true;
   }
 
   /**
@@ -398,6 +396,18 @@ export default class ScoringSet extends Backbone.Controller {
 
   get isFailed() {
     return (this.isPassed === false);
+  }
+
+  /**
+   * Check to see if there are any child models
+   * @returns {boolean}
+   */
+  get isPopulated() {
+    return Boolean(this.models?.length);
+  }
+
+  get isNotPopulated() {
+    return (this.isPopulated === false);
   }
 
   /**

--- a/js/utils.js
+++ b/js/utils.js
@@ -132,7 +132,7 @@ export function getSubsetsByType(type, subsetParent = undefined) {
  */
 export function getSubsetsByModelId(id, subsetParent = undefined) {
   const models = [Data.findById(id)];
-  let sets = getRawSets(subsetParent).filter(set => hasIntersectingHierarchy(set.models, models));
+  let sets = getRawSets(subsetParent).filter(set => hasIntersectingHierarchy(set.rawModels, models));
   if (subsetParent) {
     // Create intersection sets between the found sets and the subsetParent
     sets = sets.map(set => createIntersectionSubset([subsetParent, set]));


### PR DESCRIPTION
Fixes #19.

### Fix
* Find all intersected sets regardless of availablility, when using a modelId - now consistent with other intersection queries
* Allows sets to `update` to availability changes on their intersections


