### PR TITLE
Update: Use contextActivities API and update unavailable logic for objectives

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-scoring",
   "version": "1.1.0",
-  "framework": ">=5.31.31",
+  "framework": ">=5.48.2",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-scoring",
   "issues": "https://github.com/adaptlearning/adapt-contrib-scoring/issues/new",
   "extension": "scoring",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "adapt-contrib-scoring",
   "version": "1.1.0",
-  "framework": ">=5.31.31",
+  "framework": ">=5.48.2",
   "homepage": "https://github.com/adaptlearning/adapt-contrib-scoring",
   "issues": "https://github.com/adaptlearning/adapt-contrib-scoring/issues/new",
   "extension": "scoring",


### PR DESCRIPTION
Fixes #20.

### Update
* Add scoring sets to contextActivities API for question reporting.
* Update unavailable logic for objectives.

### Dependency
 * https://github.com/adaptlearning/adapt-contrib-scoring/pull/21
