### PR TITLE
Fix: invalid `getScaledScoreFromMinMax` value when there is no range

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -187,6 +187,7 @@ export function getSubSetByPath(path, subsetParent = undefined) {
 export function getScaledScoreFromMinMax(score, minScore, maxScore) {
   // range split into negative/positive ranges (rather than min-max normalization) depending on score
   const range = (score < 0) ? Math.abs(minScore) : maxScore;
+  if (!range) return 0;
   return Math.round((score / range) * 100);
 }
 


### PR DESCRIPTION
Fixes #23.

### Fix
* Invalid `getScaledScoreFromMinMax` value when there is no range


