### PR TITLE
Update: Improve frequency of log data and information recorded

### DIFF
--- a/js/ScoringSet.js
+++ b/js/ScoringSet.js
@@ -112,7 +112,7 @@ export default class ScoringSet extends Backbone.Controller {
   reset() {
     if (this.subsetParent) return;
     Adapt.trigger(`scoring:${this.type}:reset scoring:set:reset`, this);
-    Logging.debug(`${this.id} reset`);
+    Logging.info(`${this.id} reset`);
     this._resetObjective();
   }
 
@@ -554,7 +554,7 @@ export default class ScoringSet extends Backbone.Controller {
   _logUpdate() {
     if (!this.hasLogDataChanged) return;
     const logData = this.logData;
-    Logging.debug('scoring:update', JSON.stringify(logData));
+    Logging.info('scoring:update', JSON.stringify(logData));
     this._lastLogData = logData;
   }
 
@@ -605,7 +605,7 @@ export default class ScoringSet extends Backbone.Controller {
   onCompleted() {
     if (this.subsetParent) return;
     Adapt.trigger(`scoring:${this.type}:complete scoring:set:complete`, this);
-    Logging.debug(`${this.id} completed`);
+    Logging.info(`${this.id} completed`);
     this._completeObjective();
   }
 
@@ -616,7 +616,7 @@ export default class ScoringSet extends Backbone.Controller {
   onPassed() {
     if (this.subsetParent) return;
     Adapt.trigger(`scoring:${this.type}:passed scoring:set:passed`, this);
-    Logging.debug(`${this.id} passed`);
+    Logging.info(`${this.id} passed`);
   }
 
 }

--- a/js/ScoringSet.js
+++ b/js/ScoringSet.js
@@ -454,7 +454,7 @@ export default class ScoringSet extends Backbone.Controller {
   get isFailed() {
     return (this.isPassed === false);
   }
-  
+
   /**
    * Check to see if there are any child models
    * @returns {boolean}
@@ -518,19 +518,19 @@ export default class ScoringSet extends Backbone.Controller {
    * @param {Backbone.Model} model
    */
   _addAvailabilityModifiers(model) {
-    const questions = model.isTypeGroup('question')
-      ? [model]
-      : model.findDescendantModels('question');
+    const models = model.hasManagedChildren ? model.getChildren() : [model];
+    const questions = filterIntersectingHierarchy(this.rawQuestions, models);
     questions.forEach(questionModel => {
       const isAvailable = isAvailableInHierarchy(questionModel);
       const minScore = this.getMinScoreByModel(questionModel);
       const maxScore = this.getMaxScoreByModel(questionModel);
+      const score = this.getScoreByModel(questionModel);
       const data = {
         modelId: questionModel.get('_id'),
         minScore: isAvailable ? minScore : -minScore,
         maxScore: isAvailable ? maxScore : -maxScore
       };
-      if (questionModel.get('_isSubmitted')) data.score = -this.getScoreByModel(questionModel);
+      if (questionModel.get('_isSubmitted')) data.score = isAvailable ? score : -score;
       this.modifiers.push(data);
     });
   }

--- a/js/adapt-contrib-scoring.js
+++ b/js/adapt-contrib-scoring.js
@@ -4,6 +4,7 @@ import Logging from 'core/js/logging';
 import AdaptModelSet from './AdaptModelSet';
 import Passmark from './Passmark';
 import {
+  filterIntersectingHierarchy,
   getSubsetById,
   getSubsetsByType,
   getSubsetsByModelId,
@@ -86,7 +87,10 @@ class Scoring extends Backbone.Controller {
     const updateSubsets = !this._queuedChanges?.length
       ? this.subsets
       : this._queuedChanges.reduce((updateSubsets, model) => updateSubsets.concat(getSubsetsByModelId(model?.get('_id'))), []);
-    updateSubsets.forEach(set => set.update());
+    updateSubsets.forEach(set => {
+      const changedSubsetModels = filterIntersectingHierarchy(this._queuedChanges, set.rawModels);
+      set.update(changedSubsetModels);
+    });
     this._queuedChanges = [];
     if (!updateSubsets.length) return;
     const isComplete = this.isComplete;


### PR DESCRIPTION
Fixes #25.

### Update
* Consolidate logs into one entry per set on `update`.
* Only record data when changed from the previous entry.
*  Include context for how the set was modified for easier debugging and better understanding of the user journey.
* Added methods for retrieving model specific scores from a set.

### Dependency
* https://github.com/adaptlearning/adapt-contrib-scoring/pull/21.


